### PR TITLE
ヘッダーコンポーネントのテストを作成

### DIFF
--- a/tests/unit/AppHeader.spec.ts
+++ b/tests/unit/AppHeader.spec.ts
@@ -12,4 +12,13 @@ describe("AppHeader", () => {
     expect(wrapper.emitted().update[0]).toEqual(["2020-02-10"]);
   });
 
+  it("日付フォーマットがpatternに合っていない場合は空文字をEmmit", () => {
+    const wrapper = shallowMount(AppHeader);
+    const datePicker = wrapper.find(".datePicker");
+
+    datePicker.setValue("2020-2-1");
+    datePicker.trigger("change");
+
+    expect(wrapper.emitted().update[0]).toEqual([""]);
+  });
 });

--- a/tests/unit/AppHeader.spec.ts
+++ b/tests/unit/AppHeader.spec.ts
@@ -1,0 +1,15 @@
+import { shallowMount } from "@vue/test-utils";
+import AppHeader from "@/components/AppHeader.vue";
+
+describe("AppHeader", () => {
+  it("日付選択で値をEmmit", () => {
+    const wrapper = shallowMount(AppHeader);
+    const datePicker = wrapper.find(".datePicker");
+
+    datePicker.setValue("2020-02-10");
+    datePicker.trigger("change");
+
+    expect(wrapper.emitted().update[0]).toEqual(["2020-02-10"]);
+  });
+
+});


### PR DESCRIPTION
- 日付が選ばれると、指定のフォーマットで日付がEmmitされる
- 指定のフォーマット以外の形では、空文字がEmmitされる