### PR TITLE
評価用の星コンポーネントのテストを作成

### DIFF
--- a/tests/unit/LuckyStars.spec.ts
+++ b/tests/unit/LuckyStars.spec.ts
@@ -1,0 +1,15 @@
+import { shallowMount } from "@vue/test-utils";
+import LuckyStars from "@/components/LuckyStars.vue";
+
+describe("LuckyStars", () => {
+  it("scoreが3の場合", () => {
+    const wrapper = shallowMount(LuckyStars, {
+      propsData: { score: 3 }
+    });
+
+    expect(wrapper.text().match(/★/g)).toHaveLength(3);
+    expect(wrapper.text().match(/☆/g)).toHaveLength(2);
+    expect(wrapper.text().match(/[★☆]/g)).toHaveLength(5);
+  });
+
+});

--- a/tests/unit/LuckyStars.spec.ts
+++ b/tests/unit/LuckyStars.spec.ts
@@ -12,4 +12,24 @@ describe("LuckyStars", () => {
     expect(wrapper.text().match(/[★☆]/g)).toHaveLength(5);
   });
 
+  it("scoreが5の場合", () => {
+    const wrapper = shallowMount(LuckyStars, {
+      propsData: { score: 5 }
+    });
+
+    expect(wrapper.text().match(/★/g)).toHaveLength(5);
+    expect(wrapper.text().match(/☆/g)).toBeNull;
+    expect(wrapper.text().match(/[★☆]/g)).toHaveLength(5);
+  });
+
+  it("scoreが0の場合", () => {
+    const wrapper = shallowMount(LuckyStars, {
+      propsData: { score: 0 }
+    });
+
+    expect(wrapper.text().match(/★/g)).toBeNull;
+    expect(wrapper.text().match(/☆/g)).toHaveLength(5);
+    expect(wrapper.text().match(/[★☆]/g)).toHaveLength(5);
+  });
+
 });


### PR DESCRIPTION
- `score`に0~5を指定することで5段階評価で★と☆を表示する
- scoreが3の場合、5の場合、0の場合の、それぞれの星の数と合計を確認
