### PR TITLE
DatePickerの幅を調整

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -52,7 +52,7 @@ export default class AppHeader extends Vue {}
 }
 .dateContainer {
   padding-bottom: 16px;
-  width: 150px;
+  width: 180px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;


### PR DESCRIPTION
日付選択時に文字が溢れてしまっていたので、幅を延長。