### PR TITLE
Circle CIの設定を更新

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   js-env:
     docker:
-      - image: circleci/node:16.6.0
+      - image: cimg/node:16.6.0
 
 jobs:
   js-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             - node-v1-
       - run:
           name: Install package
-          command: npm ci
+          command: npm install
       - save_cache:
           paths:
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,18 @@ jobs:
     working_directory: ~/app
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - node-v1-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            - node-v1-{{ .Branch }}-
+            - node-v1-
       - run:
           name: Install package
           command: npm ci
+      - save_cache:
+          paths:
+            - node_modules
+          key: node-v1-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - run: 
           name: Execute test
           command: npm run test:unit
@@ -21,6 +30,11 @@ jobs:
     working_directory: ~/app
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - node-v1-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            - node-v1-{{ .Branch }}-
+            - node-v1-
       - run:
           name: Install package
           command: npm ci


### PR DESCRIPTION
#37 の対応

- パッケージインストールにキャッシュを利用
- コンビニエンスイメージをcimgに変更
- `npm ci` から `npm install` に変更